### PR TITLE
refactor: Changed CredentialFactory to use the new namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p /opt/frank/h2/
 ### section: custom-code(end)
 
 ENV application.server.type.custom=${TRANSACTION_MANAGER:-NARAYANA} \
-	credentialFactory.class=nl.nn.credentialprovider.PropertyFileCredentialFactory \
+	credentialFactory.class=org.frankframework.credentialprovider.PropertyFileCredentialFactory \
 	credentialFactory.map.properties=/opt/frank/secrets/credentials.properties
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=60 \


### PR DESCRIPTION
<img width="1306" height="18" alt="image" src="https://github.com/user-attachments/assets/451c55ea-f5f0-45e7-9bc7-991f038cb4c1" />

SEVERE [main] org.frankframework.credentialprovider.CredentialFactory.loadFactoryClasses please update your CredentialFactory properties to use the new namespace!
